### PR TITLE
feat: Add layout_bridge_output to update_state calldata in CoreContract

### DIFF
--- a/crates/l3/appchain-core-contract-client/src/interfaces/core_contract.rs
+++ b/crates/l3/appchain-core-contract-client/src/interfaces/core_contract.rs
@@ -1,7 +1,6 @@
 use appchain_utils::invoke_contract;
 use appchain_utils::LocalWalletSignerMiddleware;
 use color_eyre::Result;
-use starknet_core::types::U256;
 use starknet_core::types::{Felt, InvokeTransactionResult};
 
 pub struct CoreContract {
@@ -17,18 +16,13 @@ impl CoreContract {
     pub async fn update_state(
         &self,
         snos_output: Vec<Felt>,
-        program_output: Vec<Felt>,
-        onchain_data_hash: Felt,
-        onchain_data_size: U256,
+        layout_bridge_output: Vec<Felt>,
     ) -> Result<InvokeTransactionResult> {
-        let mut calldata = Vec::with_capacity(snos_output.len() + program_output.len() + 5);
+        let mut calldata = Vec::with_capacity(snos_output.len() + layout_bridge_output.len() + 2);
         calldata.push(Felt::from(snos_output.len()));
         calldata.extend(snos_output);
-        calldata.push(Felt::from(program_output.len()));
-        calldata.extend(program_output);
-        calldata.push(onchain_data_hash);
-        calldata.push(onchain_data_size.low().into());
-        calldata.push(onchain_data_size.high().into());
+        calldata.push(Felt::from(layout_bridge_output.len()));
+        calldata.extend(layout_bridge_output);
 
         invoke_contract(&self.signer, self.address, "update_state", calldata).await
     }


### PR DESCRIPTION

🔧 Changes made:
	•	Removed unused parameters: program_output, onchain_data_hash, onchain_data_size.
	•	Added new parameter layout_bridge_output to the function signature.
	•	Updated capacity calculation to include the new vector.
	•	Pushed the new vector’s length and elements into calldata.
